### PR TITLE
[feat](server): enhance DTLS handshake with DNS/IP-based domain valid…

### DIFF
--- a/progress.md
+++ b/progress.md
@@ -78,19 +78,19 @@ This document tracks implementation progress against the HopGate architecture an
 
 ### 2.4 DTLS Layer / Handshake
 
-- 인터페이스: [`internal/dtls/dtls.go`](internal/dtls/dtls.go)  
-  - `Session`, `Server`, `Client`.  
+- 인터페이스: [`internal/dtls/dtls.go`](internal/dtls/dtls.go)
+  - `Session`, `Server`, `Client`.
 
-- pion/dtls 전송 구현: [`internal/dtls/transport_pion.go`](internal/dtls/transport_pion.go)  
-  - `NewPionServer(PionServerConfig)`  
-    - UDP 리스너 + DTLS 서버 (`piondtls.Listen`).  
-  - `NewPionClient(PionClientConfig)`  
-    - Timeout/TLSConfig 설정, `piondtls.Dial` 사용.  
+- pion/dtls 전송 구현: [`internal/dtls/transport_pion.go`](internal/dtls/transport_pion.go)
+  - `NewPionServer(PionServerConfig)`
+    - UDP 리스너 + DTLS 서버 (`piondtls.Listen`).
+  - `NewPionClient(PionClientConfig)`
+    - Timeout/TLSConfig 설정, `piondtls.Dial` 사용.
 
-- 핸드셰이크 로직: [`internal/dtls/handshake.go`](internal/dtls/handshake.go)  
-  - 메시지: `handshakeRequest{domain, client_api_key}`, `handshakeResponse{ok, message, domain}`.  
-  - `DomainValidator` 인터페이스.  
-  - `PerformServerHandshake` / `PerformClientHandshake` 구현 완료.  
+- 핸드셰이크 로직: [`internal/dtls/handshake.go`](internal/dtls/handshake.go)
+  - 메시지: `handshakeRequest{domain, client_api_key}`, `handshakeResponse{ok, message, domain}`.
+  - `DomainValidator` 인터페이스.
+  - `PerformServerHandshake` / `PerformClientHandshake` 구현 완료.
 
 - self-signed TLS: [`internal/dtls/selfsigned.go`](internal/dtls/selfsigned.go)
   - localhost CN, SAN(DNS/IP) 포함 self-signed cert 생성.
@@ -102,6 +102,9 @@ This document tracks implementation progress against the HopGate architecture an
     - ent.Client + PostgreSQL 기반으로 `Domain` 테이블 조회.
     - 도메인 문자열은 `"host"` 또는 `"host:port"` 모두 허용하되, DB 조회 시에는 host 부분만 사용.
     - `(domain, client_api_key)` 조합이 정확히 일치하는지 검증.
+  - DTLS 핸드셰이크 DNS/IP 게이트: [`cmd/server/main.go`](cmd/server/main.go:37)
+    - `canonicalizeDomainForDNS` + `domainGateValidator` 를 사용해, 클라이언트가 제시한 도메인의 A/AAAA 레코드가 `HOP_ACME_EXPECT_IPS` 에 설정된 IPv4/IPv6 IP 중 하나 이상과 일치하는지 검사한 뒤 DB 기반 `DomainValidator` 에 위임.
+    - `HOP_ACME_EXPECT_IPS` 가 비어 있는 경우에는 DNS/IP 검증을 생략하고 DB 검증만 수행.
   - 기존 Dummy 구현: [`internal/dtls/validator_dummy.go`](internal/dtls/validator_dummy.go) 는 이제 개발/테스트용 참고 구현으로만 유지.
 
 ---


### PR DESCRIPTION
**PR 제목**

[feat] DTLS 도메인 게이트를 EXPECT_IPS 기반 DNS/IP 검증으로 교체

---

## 변경 요약 (Summary)

- DTLS 핸드셰이크에서 기존의 `HOP_SERVER_DOMAIN` 고정 문자열 비교 게이트를 제거하고,  
  `HOP_ACME_EXPECT_IPS` 기반 DNS(A/AAAA) 검증 + Admin Plane DB 검증 2단계 구조로 변경했습니다.
- 여러 도메인이 CNAME / A / AAAA 레코드를 통해 HopGate 서버 IP들을 가리키는 경우에도,  
  Admin Plane 에 등록된 `(domain, client_api_key)` 조합이면 정상적으로 허용되도록 했습니다.
- `HOP_ACME_EXPECT_IPS` 를 IPv4/IPv6 모두 지원하도록 파싱하는 헬퍼를 추가하고,  
  현재 동작을 `progress.md` 에 문서화했습니다.

---

## 상세 변경 내용 (Details)

### 1. DTLS 도메인 정규화 유틸 추가

- DTLS 핸드셰이크에서 전달되는 도메인을 DNS/DB 조회에 공통으로 사용할 수 있게 정규화:

  - [`canonicalizeDomainForDNS()`](cmd/server/main.go:37)
    - `"host"` / `"host:port"` 형태 모두 허용.
    - `net.SplitHostPort` 로 포트 제거 후, 소문자로 통일.
    - 이후 DNS(A/AAAA) 조회와 ent `Domain` 테이블 조회에 동일한 canonical host 사용.

### 2. domainGateValidator 를 DNS/IP 게이트로 재구현

- 기존: `domainGateValidator` 가 `HOP_SERVER_DOMAIN` 과의 단순 문자열 비교를 수행.
  - `handshake.domain != HOP_SERVER_DOMAIN` 인 경우 무조건 거절.
  - 결과적으로, CNAME 등 다른 호스트명은 DB에 있어도 전부 막힘.

- 변경 후: EXPECT_IPS(DNS/IP) → DB 순서로 검증하는 래퍼로 변경:

  - [`domainGateValidator`](cmd/server/main.go:54)
  - [`domainGateValidator.ValidateDomainAPIKey()`](cmd/server/main.go:65)

  동작 흐름:

  1. `domain` → [`canonicalizeDomainForDNS()`](cmd/server/main.go:37) → `d` (host only, lower-case).
  2. `expectedIPs []net.IP` (아래 `parseExpectedIPsFromEnv` 에서 구성)가 **비어 있지 않은 경우**:
     - `net.DefaultResolver.LookupIP(ctx, "ip", d)` 로 DNS 조회 (IPv4/IPv6 모두).
     - 조회된 IP 중 하나라도 `expectedIPs` 중 하나와 `ip.Equal()` 이면 통과.
     - 하나도 매치되지 않으면:
       - Warn 로그: `"dtls handshake rejected due to unexpected resolved IPs"`  
         (domain, resolved_ips, expected_ips 필드 포함)
       - `return fmt.Errorf("domain %s does not resolve to any expected IPs", d)`
  3. `expectedIPs` 가 **비어 있는 경우**:
     - DNS/IP 기반 추가 검증은 생략하고, 바로 DB 검증으로 넘어감.
  4. 마지막으로, 정규화된 `d` 와 `clientAPIKey` 를 ent 기반 `DomainValidator` 에 위임:
     - `return v.inner.ValidateDomainAPIKey(ctx, d, clientAPIKey)`

- 이 변경으로, 이제 게이트 조건은:

  1. (선택) `HOP_ACME_EXPECT_IPS` 에 명시된 IP(IPv4/IPv6)로 도메인이 resolve 되는지,  
  2. Admin Plane `domains` 테이블에 `(canonical_domain, client_api_key)` 가 정확히 존재하는지  

  두 가지로 구성됩니다.

### 3. EXPECT_IPS IPv4/IPv6 파싱 헬퍼 추가

- `HOP_ACME_EXPECT_IPS` 를 DTLS 핸드셰이크 게이트에서 재사용하고, IPv6 까지 지원하기 위한 헬퍼 추가:

  - [`parseExpectedIPsFromEnv(logger, envKey)`](cmd/server/main.go:115)

  동작:

  - `os.Getenv(envKey)` → `,` 기준 split → `strings.TrimSpace`.
  - 각 토큰을 `net.ParseIP` 로 파싱:
    - 파싱 실패 시 Warn 로그:
      - `"invalid ip in env, skipping"` + `{env, value}` 필드
    - 성공 시 `[]net.IP` 에 append.
  - 최종 로딩된 IP 목록을 Info 로그로 출력:
    - `"loaded expected handshake ips from env"` + `{env, ips}`

  예시 설정:

  ```env
  HOP_ACME_EXPECT_IPS=203.0.113.10, 2001:db8::1234
  ```

  위 설정으로 IPv4/IPv6 둘 다 허용할 수 있습니다.

### 4. DTLS 핸드셰이크에 EXPECT_IPS 적용

- 서버 메인에서 실제 DTLS 도메인 검증기를 EXPECT_IPS 기반으로 교체:

  - 도메인 검증기 준비 및 게이트 구성:  
    [`main()` 의 도메인 검증기 부분](cmd/server/main.go:784)

  - 변경 후 구성:

    ```go
    domainValidator := admin.NewEntDomainValidator(logger, dbClient)

    expectedHandshakeIPs := parseExpectedIPsFromEnv(logger, "HOP_ACME_EXPECT_IPS")
    var validator dtls.DomainValidator = &domainGateValidator{
        expectedIPs: expectedHandshakeIPs,
        inner:       domainValidator,
        logger:      logger,
    }
    ```

- 결과적으로:

  - `HOP_ACME_EXPECT_IPS` 가 설정된 경우:
    - 도메인이 해당 IP 셋으로 resolve 되지 않으면, DB 조회 전에 즉시 핸드셰이크 실패.
  - `HOP_ACME_EXPECT_IPS` 가 비어 있는 경우:
    - 기존과 같이 오직 Admin Plane + DB 기반 `(domain, client_api_key)` 검증만 수행.
  - 더 이상 DTLS 레벨에서 `HOP_SERVER_DOMAIN` 과의 단일 문자열 비교를 하지 않음:
    - 여러 도메인(예: CNAME)이 한 HopGate 인스턴스로 향하는 패턴을 자연스럽게 지원.

### 5. progress.md 문서 업데이트

- DTLS / DomainValidator 및 DNS/IP 게이트 구현을 `progress.md` 에 반영:

  - **2.4 DTLS Layer / Handshake** 섹션의 Domain Validator 부분에 설명 추가:  
    - [`progress.md`](progress.md:79)
    - [`cmd/server/main.go`](cmd/server/main.go:37) 의 `canonicalizeDomainForDNS` + `domainGateValidator` 를 참조하는 설명:
      - 클라이언트가 제시한 도메인의 A/AAAA 레코드가 `HOP_ACME_EXPECT_IPS` 에 설정된 IPv4/IPv6 IP 중 하나 이상과 일치하는지 검증.
      - `HOP_ACME_EXPECT_IPS` 가 비어 있을 때는 DNS/IP 검증은 생략하고 DB 검증만 수행.

- 3.1 Admin Plane Implementation 섹션의 체크박스들은 이미 전부 `[x]` 이었으며,  
  이번 변경은 DTLS 도메인 게이트/EXPECT_IPS 보완이므로 추가 체크박스 변경은 하지 않았습니다.  
  대신 설명을 보강해, 실제 구현과 문서가 일치하도록 맞췄습니다.

---

## 테스트 (How to test)

수동 테스트 시나리오(예시):

1. 서버 환경 변수 설정

   ```env
   # HopGate 서버 도메인(관리/메트릭용 SNI/Host) — 기존 그대로 유지
   HOP_SERVER_DOMAIN=hop-gate.mori.space

   # DTLS/ACME 대상이 되는 서버의 실제 IP들 (IPv4/IPv6 혼합 가능)
   HOP_ACME_EXPECT_IPS=203.0.113.10,2001:db8::1234

   # Admin Plane, DB, ACME 관련 필수 env 들도 기존과 동일하게 설정
   ```

2. Admin Plane 을 통해 신규 도메인 등록

   - 예: `example-proxy.com` 이 CNAME 으로 `hop-gate.mori.space` 를 가리키고 있고,  
     DNS 에서 `example-proxy.com` 이 위의 EXPECT_IPS 로 resolve 되도록 설정.
   - Admin API 호출:
     - `POST /api/v1/admin/domains/register`
     - Body: `{"domain": "example-proxy.com", "memo": "test domain via cname"}`

3. 클라이언트 핸드셰이크 성공 케이스

   - 클라이언트 설정:
     - `HOP_CLIENT_SERVER_ADDR=hop-gate.mori.space:443` (또는 실제 DTLS 포트)
     - `HOP_CLIENT_DOMAIN=example-proxy.com`
     - `HOP_CLIENT_API_KEY=...` (2번에서 발급받은 키)
   - 기대 결과:
     - DTLS 핸드셰이크 성공.
     - 서버 로그:
       - DNS resolve 로그 (acme/기존 로직 + dtls 게이트 둘 다 가능).
       - `"dtls handshake completed"` with `domain=example-proxy.com`.

4. 실패 케이스 (DNS/IP 불일치)

   - `HOP_ACME_EXPECT_IPS` 를 서버 실제 IP와 일치하지 않는 값으로 설정하거나,
   - DNS 에서 `example-proxy.com` 을 다른 IP 로 돌려놓고 핸드셰이크 시도.
   - 기대 결과:
     - DTLS 핸드셰이크 실패.
     - 서버 로그에:
       - `"dtls handshake rejected due to unexpected resolved IPs"` 경고.
       - 에러 메시지 `"domain example-proxy.com does not resolve to any expected IPs"`.

5. 실패 케이스 (DB 미등록 혹은 잘못된 key)

   - DNS/IP 는 EXPECT_IPS 와 일치하지만, Admin Plane 에 `(domain, client_api_key)` 등록이 없거나 잘못된 키 사용.
   - 기대 결과:
     - ent 기반 `DomainValidator` 에서 에러.
     - 기존과 동일하게, 도메인/키 조합이 잘못된 경우 핸드셰이크가 거절됨.

---

## 마이그레이션 / 호환성 (Backward Compatibility)

- `HOP_ACME_EXPECT_IPS` 를 사용 중인 환경에서는:
  - 기대대로 IPv4/IPv6 모두 지원하는 형태로 동작하며, 도메인이 해당 IP 들로 resolve 되어야만 핸드셰이크 통과.
- `HOP_ACME_EXPECT_IPS` 를 사용하지 않는 환경에서는:
  - DNS/IP 기반 추가 검증을 수행하지 않고, 기존과 동일하게 DB 기반 `(domain, client_api_key)` 검증만 수행.
- `HOP_SERVER_DOMAIN` 기반의 단순 문자열 비교 게이트는 제거되었지만,
  - 여전히 TLS SNI 검증(`GetCertificate` 래핑)과 HTTP Host 게이트(`hostDomainHandler`)를 통해  
    관리/메트릭/Admin Plane/정적 에셋에 대한 Host 제한은 유지한다.

이 PR 은 DTLS 핸드셰이크의 도메인 검증을 보다 실환경에 맞는 모델(“서버 IP를 향하는 여러 도메인 + Admin Plane 등록”)로 확장하면서, IPv6 지원과 보안 게이트(EXPECT_IPS)를 동시에 제공한다.